### PR TITLE
Add method to ExternalDocumentation

### DIFF
--- a/lib/swagger_parser/external_docs_attributable.rb
+++ b/lib/swagger_parser/external_docs_attributable.rb
@@ -4,8 +4,8 @@ module SwaggerParser
   module ExternalDocsAttributable
     # @return [SwaggerParser::ExternalDocumentation, nil]
     def external_docs
-      if source["external_docs"]
-        SwaggerParser::ExternalDocumentation.new(source["external_docs"])
+      if source["externalDocs"]
+        SwaggerParser::ExternalDocumentation.new(source["externalDocs"])
       end
     end
   end

--- a/lib/swagger_parser/external_documentation.rb
+++ b/lib/swagger_parser/external_documentation.rb
@@ -2,5 +2,14 @@ require "swagger_parser/source_based_object"
 
 module SwaggerParser
   class ExternalDocumentation < SourceBasedObject
+    # @return [Object]
+    def description
+      source["description"]
+    end
+
+    # @return [Object]
+    def url
+      source["url"]
+    end
   end
 end

--- a/spec/swagger_parser/external_documentation_spec.rb
+++ b/spec/swagger_parser/external_documentation_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe SwaggerParser::ExternalDocumentation do
+  let(:example_swagger_path) do
+    "examples/swagger.yml"
+  end
+
+  let(:external_documentation) do
+    swagger.external_docs
+  end
+
+  let(:swagger) do
+    SwaggerParser::FileParser.parse(example_swagger_path)
+  end
+
+  describe "#description" do
+    subject do
+      external_documentation.description
+    end
+
+    it { is_expected.to be_a String }
+  end
+
+  describe "#url" do
+    subject do
+      external_documentation.url
+    end
+
+    it { is_expected.to be_a String }
+  end
+end

--- a/spec/swagger_parser/swagger_spec.rb
+++ b/spec/swagger_parser/swagger_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe SwaggerParser::Swagger do
       swagger.external_docs
     end
 
-    it { is_expected.to be_nil }
+    it { is_expected.to be_a SwaggerParser::ExternalDocumentation }
   end
 
   describe "#host" do

--- a/spec/swagger_parser/tag_spec.rb
+++ b/spec/swagger_parser/tag_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe SwaggerParser::Swagger do
       tag.external_docs
     end
 
-    it { is_expected.to be_nil }
+    it { is_expected.to be_a SwaggerParser::ExternalDocumentation }
   end
 
   describe "#name" do


### PR DESCRIPTION
Hello!

I'm using your nice gem.
However, ``ExternalDocumentation`` hasn't been implemented completely yet.
So, I added some methods to the class on this PR.
(And fix key to refer ``externalDocs``)

Please review in your free time 🙇 